### PR TITLE
Add additional (fallback) entrypoints to package.json

### DIFF
--- a/.changeset/pretty-elephants-lick.md
+++ b/.changeset/pretty-elephants-lick.md
@@ -1,0 +1,5 @@
+---
+"react-async-ui": patch
+---
+
+Add fallback entry points to package.json to increase compatibility with bundlers and analyzers

--- a/package.json
+++ b/package.json
@@ -15,12 +15,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "import": {
+        "default": "./dist/esm/index.js",
+        "types": "./dist/esm/types/index.d.ts"
+      },
+      "require": {
+        "default": "./dist/cjs/index.js",
+        "types": "./dist/cjs/types/index.d.ts"
+      }
     },
     "./package.json": "./package.json"
   },
+  "main": "./dist/cjs/index.js",
+  "types": "./dist/cjs/types/index.d.ts",
   "files": [
     "dist/"
   ],

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "declaration": true,
+    "declarationDir": "dist/cjs/types"
   }
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -4,6 +4,6 @@
     "module": "ESNext",
     "outDir": "dist/esm",
     "declaration": true,
-    "declarationDir": "dist/types"
+    "declarationDir": "dist/esm/types"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,17 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "noImplicitAny": true,
     "moduleResolution": "node",
 
     "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": true,
     "noImplicitOverride": true,
-    "noImplicitReturns": true
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Introduces additional entrypoints to package.json to increase compatibility with bundlers and analyzers. Additionally, this adds separate `.d.ts` typings for CJS and ESM formats.