### PR TITLE
Build using tsc project references

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "tsc -b tsconfig.cjs.json tsconfig.esm.json",
+    "build": "tsc --build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "moduleResolution": "node",
+
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "dist/cjs",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "ESNext",
     "outDir": "dist/esm",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,11 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "moduleResolution": "node",
-
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "strictNullChecks": true
-  },
-  "include": ["src"]
+  "references": [
+    {
+      "path": "./tsconfig.cjs.json"
+    },
+    {
+      "path": "./tsconfig.esm.json"
+    }
+  ],
+  "files": []
 }


### PR DESCRIPTION
Slightly restructures solution to have root-level `tsconfig.json` referencing CJS and ESM projects. This turns top-level `tsconfig.json` into a single build target for `tsc --build`, instead of specifying CJS and ESM projects explicitly like before. Note that this does not change the build output at all.