### PR TITLE
Add package size badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # react-async-ui
 
+[![Bundlephobia](https://flat.badgen.net/bundlephobia/minzip/react-async-ui)](https://bundlephobia.com/package/react-async-ui)
+
 This package provides state management primitives to build modal user interactions that you can `await`, `resolve` and `reject` using a familiar, `Promise`-based API.
 
 ### Design goals


### PR DESCRIPTION
Adds Bundlephobia/badgen powered package size indicator to Readme.