### PR TITLE
Bump version to 0.2.1 for release

### DIFF
--- a/.changeset/fast-pets-brake.md
+++ b/.changeset/fast-pets-brake.md
@@ -1,5 +1,0 @@
----
-"react-async-ui": patch
----
-
-Revise README

--- a/.changeset/silly-berries-protect.md
+++ b/.changeset/silly-berries-protect.md
@@ -1,5 +1,0 @@
----
-"react-async-ui": patch
----
-
-Declare package as side effect-free in package.json to help with tree-shaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # react-async-ui
 
-## 0.1.0
+## 0.2.1
 
-Initial release
+### Patch Changes
+
+- 25dc140: Revise README
+- 5b393de: Declare package as side effect-free in package.json to help with tree-shaking
 
 ## 0.2.0
 
@@ -15,3 +18,7 @@ Initial release
 - 269e89c: Add TSDoc comments for public API surface
 - 0a17023: Add fallback entry points to package.json to increase compatibility with bundlers and analyzers
 - 6d2da9d: Improve Readme
+
+## 0.1.0
+
+Initial release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-async-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-async-ui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.26.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-async-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "author": "Stephan Deininghaus",
   "description": "Asynchronous React hooks to manage modal UI state",


### PR DESCRIPTION
Run `npx changeset version`, then `npm install` to fix up resulting version bump in package-lock.json.